### PR TITLE
feat(todo): adopt the TODO.md fragment system

### DIFF
--- a/.github/workflows/todo-collect.yml
+++ b/.github/workflows/todo-collect.yml
@@ -1,0 +1,106 @@
+# file: .github/workflows/todo-collect.yml
+# version: 1.0.0
+# guid: 8cde96aa-18bd-48c2-8d5f-681e385b8a96
+# last-edited: 2026-07-19
+
+# Fold todo.d/ fragments into TODO.md and commit the result to the default
+# branch. Opt-in by presence: every step below is a no-op in a repo without
+# todo.d/todo.ini, so this file is safe to ship anywhere.
+#
+# Unlike the changelog system there is deliberately NO pull-request check —
+# adding a task is optional, not something to enforce on every code PR.
+name: Collect TODO Fragments
+
+on:
+  schedule:
+    # Daily at 07:17 UTC. Off the hour so it does not pile into the top-of-hour
+    # crush of scheduled jobs across the org.
+    - cron: '17 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: todo-collect-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  collect:
+    name: Assemble TODO.md
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # write, not read: the collect step pushes the assembled TODO.md back to the
+    # default branch. The push normally authenticates with JF_CI_GH_PAT, which is
+    # independent of this token — but without contents: write the documented
+    # GITHUB_TOKEN fallback would be rejected, making it dead code. Matches the
+    # changelog collector in reusable-release.yml.
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Collect fragments into TODO.md
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          TODO_PAT: ${{ secrets.JF_CI_GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Opt-in by presence: repos without the fragment system stop here.
+          if [ ! -f todo.d/todo.ini ]; then
+            echo "::notice::todo.d/todo.ini not present — TODO fragments not enabled here."
+            exit 0
+          fi
+
+          if [ ! -f scripts/assemble_todo.py ]; then
+            echo "::warning::todo.d/todo.ini present but scripts/assemble_todo.py is missing; skipping."
+            exit 0
+          fi
+
+          # Only real fragments count — README.md and templates/ never do.
+          if ! find todo.d -maxdepth 1 -name '*.md' ! -name 'README.md' | grep -q .; then
+            echo "::notice::No TODO fragments to collect."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # The assembler git rm's the fragments it consumes, so the insertion
+          # and the removals are staged together.
+          python3 scripts/assemble_todo.py
+
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "::notice::Assembler produced no changes."
+            exit 0
+          fi
+
+          git add -A TODO.md todo.d
+          # [skip ci] stops this docs-only commit from retriggering the full CI.
+          git commit -m "docs(todo): collect fragments into TODO.md [skip ci]"
+
+          # Prefer the PAT (passes branch protection); fall back to the workflow
+          # token. Push to an explicit authenticated URL so we do not depend on
+          # the checkout's persisted credentials.
+          TOKEN="${TODO_PAT:-$GITHUB_TOKEN}"
+          REMOTE="https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          n=0
+          until git push "${REMOTE}" "HEAD:${DEFAULT_BRANCH}" || [ "$n" -ge 4 ]; do
+            n=$((n + 1))
+            echo "Retry $n/4 for TODO push..."
+            sleep $((2 ** n))
+            git pull --rebase "${REMOTE}" "${DEFAULT_BRANCH}"
+          done
+          [ "$n" -lt 4 ] || { echo "::error::Failed to push TODO.md"; exit 1; }
+          echo "TODO.md updated."

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,15 @@
+<!-- file: TODO.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: d3594de2-6da2-43d9-8854-3c1d57ab006a -->
+<!-- last-edited: 2026-07-19 -->
+
+# TODO
+
+## 📥 Inbox
+
+Tasks assembled from `todo.d/` fragments. Add a new task by dropping a fragment
+file in `todo.d/` rather than editing this section by hand — see
+[`todo.d/README.md`](todo.d/README.md). Checking a task off, or promoting it
+into one of the curated sections below, is a normal direct edit.
+
+<!-- todo-insert-here -->

--- a/changelog.d/20260719-adopt-todo-fragment-system.md
+++ b/changelog.d/20260719-adopt-todo-fragment-system.md
@@ -1,0 +1,14 @@
+### Added
+
+#### Adopt the `todo.d/` fragment system for `TODO.md`
+
+New tasks are now added by dropping a uniquely-named Markdown fragment in
+`todo.d/` instead of editing `TODO.md` directly, so parallel PRs no longer
+collide on the TODO list — the same fragment-per-change model this repo already
+uses for `CHANGELOG.md`.
+
+`scripts/assemble_todo.py` folds fragments in below the
+`<!-- todo-insert-here -->` marker and deletes the ones it consumed;
+`.github/workflows/todo-collect.yml` runs it daily and on `workflow_dispatch`.
+The system is add-only (checking a task off stays a direct edit) and opt-in by
+presence of `todo.d/todo.ini`.

--- a/scripts/assemble_todo.py
+++ b/scripts/assemble_todo.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+# file: scripts/assemble_todo.py
+# version: 1.1.0
+# guid: 93782e44-c995-4fd4-8293-91e361f7b301
+# last-edited: 2026-07-19
+
+"""Assemble TODO.md from per-task fragment files in todo.d/.
+
+This is the TODO-file counterpart of the ``changelog.d/`` + ``scriv`` system.
+The problem is the same one scriv solves for changelogs: when many contributors
+and AI agents open PRs in parallel, every PR that wants to add a task edits the
+same region of the same file and they all conflict. A fragment-per-task means
+no two PRs ever touch the same file.
+
+scriv is changelog-only and has no TODO equivalent, so the assembler is ours.
+The model is deliberately identical to scriv's, including fragment deletion:
+
+* **Opt-in by presence.** No ``todo.d/todo.ini`` means this script exits 0
+  having done nothing, so the collecting workflow is safe to ship to repos that
+  have not adopted the system.
+* **Add-only.** Fragments *add* tasks at the insert marker. Checking a task off
+  or deleting it stays a direct edit of ``TODO.md`` — a low-collision operation
+  that gains nothing from fragments.
+* **Consumed fragments are deleted**, via ``git rm`` inside a work tree so the
+  removal lands in the same commit as the insertion. Without this, every collect
+  would re-append every task forever.
+
+Usage:
+    python3 scripts/assemble_todo.py              # collect and delete fragments
+    python3 scripts/assemble_todo.py --dry-run    # print the result, touch nothing
+    python3 scripts/assemble_todo.py --keep       # collect but leave fragments
+    python3 scripts/assemble_todo.py --check      # exit 1 if fragments are pending
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import datetime
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+CONFIG_FILE = Path("todo.d/todo.ini")
+
+# A fragment whose body is nothing but HTML comments (an untouched scaffold) is
+# an intentional no-op: it is deleted without contributing anything, matching how
+# scriv treats a fully-commented changelog fragment.
+HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+
+VERSION_HEADER = re.compile(
+    r"^(<!--\s*version:\s*)(\d+)\.(\d+)\.(\d+)(\s*-->)$", re.M
+)
+LAST_EDITED_HEADER = re.compile(
+    r"^(<!--\s*last-edited:\s*)(\S+)(\s*-->)$", re.M
+)
+
+
+class AssemblyError(RuntimeError):
+    """A condition that should fail the run loudly rather than silently pass."""
+
+
+def load_config() -> configparser.SectionProxy | None:
+    """Return the ``[todo]`` config section, or None when not opted in."""
+    if not CONFIG_FILE.is_file():
+        return None
+    parser = configparser.ConfigParser()
+    parser.read(CONFIG_FILE)
+    if not parser.has_section("todo"):
+        raise AssemblyError(f"{CONFIG_FILE} exists but has no [todo] section.")
+    return parser["todo"]
+
+
+def find_fragments(fragment_dir: Path) -> list[Path]:
+    """Return real fragments, oldest filename first.
+
+    The scaffolding — ``README.md``, ``templates/``, and the ``.ini`` config —
+    lives in the same directory and is never a fragment. Sorting by name is what
+    makes the ``<YYYY-MM-DD>-<slug>.md`` convention yield chronological order.
+    """
+    if not fragment_dir.is_dir():
+        return []
+    return sorted(
+        path for path in fragment_dir.glob("*.md") if path.name != "README.md"
+    )
+
+
+def fragment_body(path: Path) -> str:
+    """Return a fragment's contributed Markdown, or '' if it is a no-op."""
+    text = path.read_text(encoding="utf-8")
+    if not HTML_COMMENT.sub("", text).strip():
+        return ""
+    return text.strip("\n")
+
+
+def bump_header(text: str, today: str) -> str:
+    """Bump the output file's patch version and refresh ``last-edited``.
+
+    The collect commit is a real modification of the output file, so the
+    assembler maintains its header rather than leaving CI to complain about a
+    stale one.
+
+    Best-effort by design: each header line is updated only if present. Adding
+    tasks is the job, and header upkeep must never be the reason a scheduled
+    collect fails — repos that adopt this system carry heterogeneous headers,
+    and plenty have a `version:` line but no `last-edited:` (or neither). A
+    missing line is reported as a warning and the collect proceeds.
+    """
+
+    def _bump(match: re.Match[str]) -> str:
+        major, minor, patch = (
+            match.group(2),
+            match.group(3),
+            int(match.group(4)),
+        )
+        return f"{match.group(1)}{major}.{minor}.{patch + 1}{match.group(5)}"
+
+    text, count = VERSION_HEADER.subn(_bump, text, count=1)
+    if not count:
+        print("warning: no '<!-- version: X.Y.Z -->' header to bump.")
+
+    text, count = LAST_EDITED_HEADER.subn(
+        lambda m: f"{m.group(1)}{today}{m.group(3)}", text, count=1
+    )
+    if not count:
+        print("warning: no '<!-- last-edited: ... -->' header to refresh.")
+    return text
+
+
+def insert_at_marker(text: str, marker: str, addition: str) -> str:
+    """Insert ``addition`` directly below the marker line.
+
+    Each collect lands its batch at the marker, so the most recently collected
+    tasks sit at the top of the inbox — the same "newest at the marker" ordering
+    scriv uses for release sections.
+    """
+    marker_line = re.compile(
+        rf"^([ \t]*<!--\s*{re.escape(marker)}\s*-->[ \t]*)$", re.M
+    )
+    match = marker_line.search(text)
+    if not match:
+        raise AssemblyError(
+            f"Output file has no '<!-- {marker} -->' marker; refusing to guess where tasks belong."
+        )
+    return text[: match.end()] + f"\n\n{addition}" + text[match.end() :]
+
+
+def git_rm(paths: list[Path]) -> None:
+    """Delete consumed fragments, staging the removal when inside a work tree."""
+    try:
+        subprocess.run(
+            ["git", "rm", "--quiet", "--", *(str(p) for p in paths)],
+            check=True,
+            capture_output=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # Not a git work tree (or git is unavailable) — a plain unlink still
+        # leaves the tree in the correct end state.
+        for path in paths:
+            path.unlink(missing_ok=True)
+
+
+def main() -> int:
+    """Parse arguments, collect fragments, and return the process exit code."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the assembled output file to stdout and change nothing",
+    )
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="write the output file but leave the consumed fragments in place",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 if any fragment is pending collection; change nothing",
+    )
+    args = parser.parse_args()
+
+    config = load_config()
+    if config is None:
+        print(f"{CONFIG_FILE} not present — TODO fragments not enabled here.")
+        return 0
+
+    fragment_dir = Path(config.get("fragment_directory", "todo.d"))
+    output_file = Path(config.get("output_file", "TODO.md"))
+    marker = config.get("insert_marker", "todo-insert-here")
+
+    fragments = find_fragments(fragment_dir)
+    if args.check:
+        for path in fragments:
+            print(f"pending: {path}")
+        return 1 if fragments else 0
+
+    if not fragments:
+        print(f"No fragments in {fragment_dir}/ — nothing to collect.")
+        return 0
+
+    if not output_file.is_file():
+        raise AssemblyError(f"{output_file} does not exist.")
+
+    bodies = [(path, fragment_body(path)) for path in fragments]
+    contributed = [body for _, body in bodies if body]
+
+    for path, body in bodies:
+        print(f"{'no-op ' if not body else 'collect'} {path}")
+
+    if contributed:
+        text = insert_at_marker(
+            output_file.read_text(encoding="utf-8"),
+            marker,
+            "\n\n".join(contributed),
+        )
+        if config.getboolean("bump_version", fallback=True):
+            today = datetime.date.today().isoformat()
+            text = bump_header(text, today)
+
+        if args.dry_run:
+            sys.stdout.write(text)
+            return 0
+        output_file.write_text(text, encoding="utf-8")
+        print(f"Wrote {len(contributed)} task block(s) into {output_file}.")
+    elif args.dry_run:
+        print("All fragments are no-ops; output file unchanged.")
+        return 0
+
+    if not args.keep:
+        git_rm(fragments)
+        print(f"Removed {len(fragments)} consumed fragment(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except AssemblyError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/assemble_todo.py
+++ b/scripts/assemble_todo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # file: scripts/assemble_todo.py
-# version: 1.1.0
-# guid: 93782e44-c995-4fd4-8293-91e361f7b301
+# version: 1.2.0
+# guid: af7ef324-6c69-411e-b1a9-98c9ba2b31e3
 # last-edited: 2026-07-19
 
 """Assemble TODO.md from per-task fragment files in todo.d/.
@@ -50,10 +50,12 @@ CONFIG_FILE = Path("todo.d/todo.ini")
 HTML_COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
 
 VERSION_HEADER = re.compile(
-    r"^(<!--\s*version:\s*)(\d+)\.(\d+)\.(\d+)(\s*-->)$", re.M
+    r"^(<!--\s*version:\s*)(\d+)\.(\d+)\.(\d+)(\s*-->)$",
+    re.M,
 )
 LAST_EDITED_HEADER = re.compile(
-    r"^(<!--\s*last-edited:\s*)(\S+)(\s*-->)$", re.M
+    r"^(<!--\s*last-edited:\s*)(\S+)(\s*-->)$",
+    re.M,
 )
 
 
@@ -81,9 +83,8 @@ def find_fragments(fragment_dir: Path) -> list[Path]:
     """
     if not fragment_dir.is_dir():
         return []
-    return sorted(
-        path for path in fragment_dir.glob("*.md") if path.name != "README.md"
-    )
+    candidates = fragment_dir.glob("*.md")
+    return sorted(p for p in candidates if p.name != "README.md")
 
 
 def fragment_body(path: Path) -> str:
@@ -121,7 +122,9 @@ def bump_header(text: str, today: str) -> str:
         print("warning: no '<!-- version: X.Y.Z -->' header to bump.")
 
     text, count = LAST_EDITED_HEADER.subn(
-        lambda m: f"{m.group(1)}{today}{m.group(3)}", text, count=1
+        lambda m: f"{m.group(1)}{today}{m.group(3)}",
+        text,
+        count=1,
     )
     if not count:
         print("warning: no '<!-- last-edited: ... -->' header to refresh.")
@@ -136,12 +139,13 @@ def insert_at_marker(text: str, marker: str, addition: str) -> str:
     scriv uses for release sections.
     """
     marker_line = re.compile(
-        rf"^([ \t]*<!--\s*{re.escape(marker)}\s*-->[ \t]*)$", re.M
+        rf"^([ \t]*<!--\s*{re.escape(marker)}\s*-->[ \t]*)$",
+        re.M,
     )
     match = marker_line.search(text)
     if not match:
         raise AssemblyError(
-            f"Output file has no '<!-- {marker} -->' marker; refusing to guess where tasks belong."
+            f"No '<!-- {marker} -->' marker in the output file; refusing to guess where tasks belong.",
         )
     return text[: match.end()] + f"\n\n{addition}" + text[match.end() :]
 

--- a/todo.d/README.md
+++ b/todo.d/README.md
@@ -1,0 +1,71 @@
+<!-- file: todo.d/README.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: 6c21d065-e0c0-4e8f-8cf8-8646cc6239bb -->
+<!-- last-edited: 2026-07-19 -->
+
+# TODO fragments (`todo.d/`)
+
+New tasks are **added** to `TODO.md` by dropping a small, uniquely-named
+Markdown fragment in this directory. A scheduled job folds every fragment into
+the `## 📥 Inbox` section of `TODO.md` and deletes the fragments it consumed.
+
+This exists for the same reason [`changelog.d/`](../changelog.d/README.md) does:
+many contributors and AI agents open PRs in parallel, and if every one of them
+edited the same region of `TODO.md` directly, every PR would collide. A
+fragment-per-task means no two PRs touch the same file, so there are no merge
+conflicts on the TODO list.
+
+> The changelog system uses the maintained OSS tool
+> [`scriv`](https://scriv.readthedocs.io/). scriv is changelog-only and has no
+> TODO equivalent, so assembly here is done by
+> [`scripts/assemble_todo.py`](../scripts/assemble_todo.py). The fragment model
+> is otherwise identical, deletion-on-collect included.
+
+## Add a task
+
+Create `todo.d/<YYYY-MM-DD>-<short-slug>.md` — the date prefix is what makes
+fragments sort chronologically, and the slug is what keeps two people adding a
+task on the same day from colliding:
+
+```markdown
+- [ ] **TODO-PIN** Pin all reusable-workflow `uses:` refs to commit SHAs —
+      several downstream repos pin a github-common SHA that no longer exists on
+      `main`, so their super-linter job cannot resolve the workflow at all.
+```
+
+Copy [`templates/new_fragment.md`](templates/new_fragment.md) for a scaffold.
+There is deliberately **no PR check** for TODO fragments (unlike changelog
+fragments) — adding a task is optional, not something to enforce on every PR.
+
+## Rules
+
+- **Add-only.** Fragments _add_ tasks. Checking a task off, deleting it, or
+  promoting it out of the Inbox into a curated section is a normal direct edit
+  of `TODO.md` — those are low-collision and gain nothing from fragments.
+- **One fragment per logical task** (or per tight cluster of related subtasks).
+- Fragments are **exempt from the file-header rule** — do not add the
+  `file`/`version`/`guid` header. The body is folded into `TODO.md` verbatim, so
+  a header would leak into the assembled document. They are also excluded from
+  markdownlint and prettier via `.markdownlintignore` / `.prettierignore`.
+- A fragment that is **entirely HTML comments** is treated as an intentional
+  no-op: it is deleted on collect without contributing anything. Comment out a
+  fragment rather than deleting it if you want the collector to drop it quietly.
+
+## How assembly works
+
+- [`scripts/assemble_todo.py`](../scripts/assemble_todo.py) inserts every
+  fragment body directly below the `<!-- todo-insert-here -->` marker in
+  `TODO.md`, bumps that file's `version:` header, and `git rm`s the consumed
+  fragments so the insertion and removals land in one commit.
+- [`.github/workflows/todo-collect.yml`](../.github/workflows/todo-collect.yml)
+  runs it daily and on `workflow_dispatch`, committing with `[skip ci]`.
+- Configuration lives in [`todo.ini`](todo.ini). **That file's presence is what
+  opts a repository in** — the assembler and the workflow both self-skip when it
+  is absent, so the workflow is harmless in a repo that has not adopted this.
+
+Run it yourself to preview:
+
+```bash
+python3 scripts/assemble_todo.py --dry-run   # print the result, change nothing
+python3 scripts/assemble_todo.py --check     # exit 1 if fragments are pending
+```

--- a/todo.d/templates/new_fragment.md
+++ b/todo.d/templates/new_fragment.md
@@ -1,0 +1,23 @@
+<!--
+Scaffold for a TODO fragment. Do NOT add a file/version/guid header here — the
+body of this file is folded into TODO.md verbatim, so a header would leak into
+the assembled document.
+
+Copy this file to todo.d/<YYYY-MM-DD>-<short-slug>.md, then replace everything
+below with your task(s). The unique filename is the whole point: parallel PRs
+each add their own fragment and never collide on TODO.md.
+
+A fragment ADDS tasks. Checking a task off or deleting it is a direct edit of
+TODO.md — that is low-collision and needs no fragment.
+
+Leave this file entirely commented out and the assembler treats it as an
+intentional no-op: the fragment is deleted without adding anything, matching
+how scriv handles an untouched changelog scaffold.
+
+Format: standard Markdown task-list items. Give the task a short bold tag when
+it needs to be referred to elsewhere, and wrap continuation lines at 80 columns
+with 6-space indentation to match the existing TODO.md style.
+-->
+
+- [ ] **TAG** One-line statement of the task — followed by enough context that
+      a reader six months from now knows why it is here and what "done" means.

--- a/todo.d/todo.ini
+++ b/todo.d/todo.ini
@@ -1,0 +1,24 @@
+# file: todo.d/todo.ini
+# version: 1.0.0
+# guid: eae1124c-8fd8-44bd-b44d-597483baa7fb
+
+# Configuration for assembling TODO.md from todo.d/ fragments.
+# Deliberately mirrors changelog.d/scriv.ini: this file's *presence* is what
+# opts a repository in. Every workflow and the assembler itself self-skip when
+# it is absent, so shipping todo-collect.yml to a repo that has not adopted the
+# system yet is a no-op.
+#
+# Assembled by scripts/assemble_todo.py (no OSS equivalent of scriv exists for
+# TODO files, so the assembler is ours — the fragment model is identical).
+[todo]
+# Where fragments live and what they are folded into.
+fragment_directory = todo.d
+output_file = TODO.md
+
+# The HTML comment in output_file that new tasks are inserted directly after.
+# Assembly is a hard no-op if the marker is missing.
+insert_marker = todo-insert-here
+
+# Bump output_file's `version:` header patch number and refresh `last-edited:`
+# on every successful collect, per the repo-wide file-header rule.
+bump_version = true


### PR DESCRIPTION
## Summary

Adopts the **TODO.md fragment system** — the TODO-file counterpart of the
`changelog.d/` + `scriv` system this repo already uses — so parallel PRs stop
colliding on `TODO.md`.

New tasks are added by dropping a uniquely-named Markdown fragment in `todo.d/`
instead of editing `TODO.md` directly. `scripts/assemble_todo.py` folds them in
below the `<!-- todo-insert-here -->` marker and `git rm`s the fragments it
consumed, so the insertion and removals land in one commit.

| File | Role |
|---|---|
| `todo.d/todo.ini` | Config. **Its presence is what opts this repo in.** |
| `todo.d/README.md` | Contributor guide. |
| `todo.d/templates/new_fragment.md` | Fragment scaffold. |
| `scripts/assemble_todo.py` | The assembler (`--dry-run`, `--check`, `--keep`). |
| `.github/workflows/todo-collect.yml` | Daily + `workflow_dispatch` collector. |

- **Add-only** — fragments add tasks; checking one off or promoting it out of the
  Inbox is a normal direct edit of `TODO.md`.
- **No PR check** (unlike changelog fragments) — adding a task is optional and
  shouldn't gate code PRs.
- **Opt-in by presence** of `todo.d/todo.ini`; the workflow self-skips without it.

This repo had no `TODO.md`, so one was created with just the Inbox section — matching how the changelog rollout seeded a `CHANGELOG.md` where none existed.

Built and validated in falkcorp/github-common#328 (round-trip verified there:
a fragment folds into the Inbox and is deleted, and an all-comments fragment is
dropped as an intentional no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vU67T2LJDCbYTBs9ZFAf2
