### PR TITLE
docs(agents): document changelog/TODO fragment system for AI agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 <!-- file: .github/copilot-instructions.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: a3f7e2d1-8b4c-4e6a-9f1d-2c5b3a7e8f0d -->
-<!-- last-edited: 2026-06-13 -->
+<!-- last-edited: 2026-07-21 -->
 
 # gcommon — Additional Context
 
@@ -25,3 +25,20 @@ Go SDK for gcommon protocol buffers with shared utilities. Language: Go.
 
 - Module path uses `buf.build/falkcorp/gcommon`
 - Use `git clone --recurse-submodules` to populate `.standards/`
+
+
+## 📝 Changelog & TODO — Use the Fragment System (MANDATORY)
+
+**Do not hand-edit `CHANGELOG.md`, and do not add new tasks straight into the
+`TODO.md` inbox.** Both files are assembled from per-change fragments so that
+parallel PRs never collide on them.
+
+- **`CHANGELOG.md` is assembled, not hand-edited.** Add a fragment under
+  `changelog.d/` (run `scriv create`, or write the Markdown file by hand). The
+  fragments are folded into `CHANGELOG.md` at release time by `scriv`, and a CI
+  check (`changelog-check.yml`) requires one on each PR. See `changelog.d/README.md`.
+- **New `TODO.md` tasks are added via fragments.** Drop a Markdown fragment in
+  `todo.d/` (see `todo.d/README.md`) instead of editing the `## 📥 Inbox`
+  section. `scripts/assemble_todo.py` folds fragments in daily. This is
+  **add-only**: checking a task off or removing it is a normal direct edit of
+  `TODO.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- file: CLAUDE.md -->
-<!-- version: 1.0.0 -->
+<!-- version: 1.1.0 -->
 <!-- guid: b5d8f3a2-7c1e-4d9b-8a2f-3e6c1b4d7f2a -->
-<!-- last-edited: 2026-06-13 -->
+<!-- last-edited: 2026-07-21 -->
 
 # gcommon
 
@@ -15,3 +15,20 @@ Always clone with `git clone --recurse-submodules` so these are available.
 Key files:
 - **File headers (MANDATORY):** `.standards/instructions/file-headers.md`
 - **Commit format:** `.standards/instructions/commit-messages.md`
+
+
+## 📝 Changelog & TODO — Use the Fragment System (MANDATORY)
+
+**Do not hand-edit `CHANGELOG.md`, and do not add new tasks straight into the
+`TODO.md` inbox.** Both files are assembled from per-change fragments so that
+parallel PRs never collide on them.
+
+- **`CHANGELOG.md` is assembled, not hand-edited.** Add a fragment under
+  `changelog.d/` (run `scriv create`, or write the Markdown file by hand). The
+  fragments are folded into `CHANGELOG.md` at release time by `scriv`, and a CI
+  check (`changelog-check.yml`) requires one on each PR. See `changelog.d/README.md`.
+- **New `TODO.md` tasks are added via fragments.** Drop a Markdown fragment in
+  `todo.d/` (see `todo.d/README.md`) instead of editing the `## 📥 Inbox`
+  section. `scripts/assemble_todo.py` folds fragments in daily. This is
+  **add-only**: checking a task off or removing it is a normal direct edit of
+  `TODO.md`.

--- a/changelog.d/document-fragment-system-for-agents.md
+++ b/changelog.d/document-fragment-system-for-agents.md
@@ -1,0 +1,8 @@
+### Changed
+
+#### Document the changelog/TODO fragment system for AI agents
+
+`CLAUDE.md` and `.github/copilot-instructions.md` now instruct AI agents to use
+the `changelog.d/` and `todo.d/` fragment systems instead of editing
+`CHANGELOG.md` or the `TODO.md` inbox directly, preventing parallel-PR
+collisions on those files.


### PR DESCRIPTION
## Summary

The `changelog.d/` and `todo.d/` fragment systems are set up in this repo, but nothing in `CLAUDE.md` or `.github/copilot-instructions.md` told AI agents to use them — so an agent would edit `CHANGELOG.md` / the `TODO.md` inbox directly and hit merge conflicts.

Adds a self-contained **"Changelog & TODO — Use the Fragment System (MANDATORY)"** section to both files (creating either if the repo lacked it).

## Changes
- `CLAUDE.md` — append section (or create); bump version
- `.github/copilot-instructions.md` — append section (or create); bump version
- `changelog.d/` — fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)